### PR TITLE
Allows use on systems with nmcli where iwlist is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var geocodeWifi = require('geocode-wifi')
-var wifiScanner = require('node-wifiscanner')
+var wifiScanner = require('node-wifiscanner2')
 
 module.exports = function (cb) {
   wifiScanner.scan(function (err, towers) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wifi-triangulate",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Finds your current position on planet earth using the wifi access points in your vicinity",
   "main": "index.js",
   "scripts": {
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/watson/wifi-triangulate",
   "dependencies": {
     "geocode-wifi": "^1.0.1",
-    "node-wifiscanner": "^0.2.1"
+    "node-wifiscanner2": "^1.2.0"
   },
   "devDependencies": {
     "proxyquire": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wifi-triangulate",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "description": "Finds your current position on planet earth using the wifi access points in your vicinity",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ proxyquire('./', {
 })
 
 var test = require('tape')
-var wifiScanner = require('node-wifiscanner')
+var wifiScanner = require('node-wifiscanner2')
 var wifiTriangulate = require('./')
 
 test('wifi error', function (t) {


### PR DESCRIPTION
Changed dependency on module node-wifiscanner to node-wifiscanner2 to allow this module to work on linux systems with nmcli rather than iwlist.
